### PR TITLE
feat: replace home view with Korale landing

### DIFF
--- a/public/assets/korale/hero-coral-pattern.svg
+++ b/public/assets/korale/hero-coral-pattern.svg
@@ -1,0 +1,31 @@
+<svg width="1440" height="900" viewBox="0 0 1440 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="900" fill="url(#paint0_radial_hero)"/>
+  <g opacity="0.35" filter="url(#filter0_f_hero)">
+    <path d="M1220 220C1360 360 1350 640 1120 700C890 760 800 520 650 460C500 400 320 470 180 360C40 250 80 70 260 40C440 10 500 220 670 240C840 260 1080 80 1220 220Z" fill="url(#paint1_linear_hero)"/>
+  </g>
+  <g opacity="0.28">
+    <path d="M1360 140C1260 240 1180 280 1080 260C980 240 900 160 760 200C620 240 540 380 420 380C300 380 220 260 140 220" stroke="url(#paint2_linear_hero)" stroke-width="60" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <defs>
+    <filter id="filter0_f_hero" x="-80" y="-120" width="1630" height="1110" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur stdDeviation="80" result="effect1_foregroundBlur_hero"/>
+    </filter>
+    <radialGradient id="paint0_radial_hero" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1200 -80) rotate(125) scale(1200 900)">
+      <stop stop-color="#FF8FA3" stop-opacity="0.6"/>
+      <stop offset="0.38" stop-color="#FF6F91" stop-opacity="0.4"/>
+      <stop offset="1" stop-color="#2B1A38" stop-opacity="0.7"/>
+    </radialGradient>
+    <linearGradient id="paint1_linear_hero" x1="1280" y1="120" x2="200" y2="740" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFB3C1"/>
+      <stop offset="0.45" stop-color="#F25E8E"/>
+      <stop offset="1" stop-color="#7128A0"/>
+    </linearGradient>
+    <linearGradient id="paint2_linear_hero" x1="1360" y1="140" x2="140" y2="320" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFE1EA"/>
+      <stop offset="0.4" stop-color="#F688B4"/>
+      <stop offset="1" stop-color="#5F1D8C" stop-opacity="0.4"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/assets/korale/hero-coral-reef.svg
+++ b/public/assets/korale/hero-coral-reef.svg
@@ -1,0 +1,28 @@
+<svg width="760" height="520" viewBox="0 0 760 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g filter="url(#filter0_d_reef)">
+    <path d="M120 360C60 290 80 210 140 170C200 130 260 170 300 190C340 210 360 170 390 150C420 130 470 120 510 150C550 180 570 250 620 270C670 290 700 260 720 300C740 340 690 420 610 430C530 440 490 400 440 380C390 360 320 380 260 390C200 400 150 430 120 360Z" fill="url(#paint0_linear_reef)"/>
+    <path d="M214 275C198 261 205 229 225 214C245 199 268 209 280 215C292 221 298 211 309 204C320 197 340 194 353 204C366 214 372 242 391 249C410 256 422 243 430 258C438 273 414 304 375 309C336 314 317 299 292 289C267 279 232 290 214 275Z" fill="url(#paint1_linear_reef)"/>
+  </g>
+  <defs>
+    <filter id="filter0_d_reef" x="0" y="0" width="760" height="540" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="30"/>
+      <feGaussianBlur stdDeviation="40"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.1725 0 0 0 0 0.0627 0 0 0 0 0.2863 0 0 0 0.4 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_reef"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_reef" result="shape"/>
+    </filter>
+    <linearGradient id="paint0_linear_reef" x1="84" y1="196" x2="676" y2="392" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFD1DC"/>
+      <stop offset="0.3" stop-color="#FF8FA3"/>
+      <stop offset="0.65" stop-color="#E24B8C"/>
+      <stop offset="1" stop-color="#6120A8"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear_reef" x1="205" y1="215" x2="424" y2="296" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFE6EF"/>
+      <stop offset="0.45" stop-color="#F590BA"/>
+      <stop offset="1" stop-color="#7D3CC7"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/sections/home/home-client-highlights.tsx
+++ b/src/sections/home/home-client-highlights.tsx
@@ -1,0 +1,83 @@
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import { alpha, styled } from '@mui/material/styles';
+
+// ----------------------------------------------------------------------
+
+const HighlightCard = styled(Paper)(({ theme }) => ({
+  height: '100%',
+  padding: theme.spacing(4),
+  borderRadius: theme.spacing(3),
+  border: `1px solid ${alpha(theme.palette.secondary.light, 0.24)}`,
+  backgroundColor: alpha(theme.palette.secondary.lighter, 0.2),
+  backdropFilter: 'blur(10px)',
+}));
+
+const highlights = [
+  {
+    client: 'Seastar Bank',
+    impact: 'Scaled a 14-person Korale pod across product and risk within eight weeks.',
+    stat: '32% faster lending approvals',
+  },
+  {
+    client: 'NorthCurrent Energy',
+    impact: 'Introduced leased data stewards while coaching internal product leads.',
+    stat: 'Adoption up 45% in 3 months',
+  },
+  {
+    client: 'Lotus Mobility',
+    impact: 'Blended Korale storytellers with UX strategists to relaunch rider onboarding.',
+    stat: 'CSAT 4.8 ★ across new cohorts',
+  },
+];
+
+// ----------------------------------------------------------------------
+
+export default function HomeClientHighlights() {
+  return (
+    <Box
+      component="section"
+      sx={{
+        py: { xs: 12, md: 16 },
+        background: (theme) =>
+          `radial-gradient(circle at 20% 20%, ${alpha(theme.palette.secondary.lighter, 0.55)} 0%, transparent 55%),
+          radial-gradient(circle at 80% 0%, ${alpha(theme.palette.primary.light, 0.4)} 0%, transparent 50%),
+          ${theme.palette.background.paper}`,
+      }}
+    >
+      <Container maxWidth="lg">
+        <Stack spacing={3} sx={{ maxWidth: 720 }}>
+          <Typography variant="overline" color="secondary">
+            Client highlights
+          </Typography>
+          <Typography variant="h3" sx={{ fontWeight: 800 }}>
+            Trusted by teams who build with empathy and pace.
+          </Typography>
+          <Typography sx={{ color: 'text.secondary', fontSize: { xs: 18, md: 20 } }}>
+            Korale pods grow inside your organisation, creating coral reefs of capability that outlast the
+            initial engagement.
+          </Typography>
+        </Stack>
+
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} sx={{ mt: { xs: 6, md: 8 } }}>
+          {highlights.map((highlight) => (
+            <HighlightCard key={highlight.client}>
+              <Stack spacing={2}>
+                <Typography variant="subtitle2" sx={{ color: 'secondary.darker', letterSpacing: 1, textTransform: 'uppercase' }}>
+                  {highlight.client}
+                </Typography>
+                <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                  {highlight.stat}
+                </Typography>
+                <Typography sx={{ color: 'text.secondary' }}>{highlight.impact}</Typography>
+              </Stack>
+            </HighlightCard>
+          ))}
+        </Stack>
+      </Container>
+    </Box>
+  );
+}

--- a/src/sections/home/home-contact-cta.tsx
+++ b/src/sections/home/home-contact-cta.tsx
@@ -1,0 +1,48 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import { alpha } from '@mui/material/styles';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+
+// ----------------------------------------------------------------------
+
+export default function HomeContactCta() {
+  return (
+    <Box
+      component="section"
+      sx={{
+        py: { xs: 12, md: 16 },
+        background: (theme) =>
+          `linear-gradient(135deg, ${alpha(theme.palette.secondary.main, 0.95)} 0%, ${alpha(
+            theme.palette.primary.main,
+            0.92
+          )} 100%)`,
+        color: 'common.white',
+      }}
+    >
+      <Container maxWidth="lg">
+        <Stack spacing={3} sx={{ maxWidth: 640 }}>
+          <Typography variant="overline" sx={{ letterSpacing: 2 }}>
+            Start your coral formation
+          </Typography>
+          <Typography variant="h3" sx={{ fontWeight: 800 }}>
+            Ready to see how Korale can lease, coach, and elevate your next delivery wave?
+          </Typography>
+          <Typography sx={{ color: alpha('#FFFFFF', 0.86), fontSize: { xs: 18, md: 20 } }}>
+            Share your upcoming milestones and we&apos;ll map the right Korale pod, complete with embedded
+            leadership and onboarding rituals tailored for your context.
+          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Button size="large" color="inherit" variant="contained">
+              Book a discovery call
+            </Button>
+            <Button size="large" color="inherit" variant="outlined" sx={{ borderColor: alpha('#FFFFFF', 0.5) }}>
+              Download Korale overview
+            </Button>
+          </Stack>
+        </Stack>
+      </Container>
+    </Box>
+  );
+}

--- a/src/sections/home/home-hero-korale.tsx
+++ b/src/sections/home/home-hero-korale.tsx
@@ -1,0 +1,100 @@
+import { m } from 'framer-motion';
+
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import { alpha, styled } from '@mui/material/styles';
+
+import { HEADER } from 'src/layouts/config-layout';
+
+import { varFade, MotionContainer } from 'src/components/animate';
+
+// ----------------------------------------------------------------------
+
+const HeroRoot = styled('section')(({ theme }) => ({
+  position: 'relative',
+  background: `linear-gradient(135deg, ${alpha(theme.palette.primary.dark, 0.88)} 0%, ${alpha(
+    theme.palette.secondary.main,
+    0.92
+  )} 45%, ${alpha(theme.palette.primary.main, 0.95)} 100%)`,
+  color: theme.palette.common.white,
+  paddingTop: `${HEADER.H_MOBILE + 40}px`,
+  paddingBottom: theme.spacing(16),
+  overflow: 'hidden',
+  [theme.breakpoints.up('sm')]: {
+    paddingTop: `${HEADER.H_DESKTOP + 80}px`,
+  },
+}));
+
+const CoralBackdrop = styled('img')(({ theme }) => ({
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  opacity: 0.24,
+  mixBlendMode: theme.palette.mode === 'light' ? 'screen' : 'luminosity',
+}));
+
+const CoralAccent = styled('img')(({ theme }) => ({
+  position: 'absolute',
+  right: -120,
+  bottom: -80,
+  width: 420,
+  opacity: 0.32,
+  filter: 'drop-shadow(0 40px 80px rgba(0,0,0,0.25))',
+  [theme.breakpoints.up('md')]: {
+    right: 40,
+    bottom: -40,
+    width: 520,
+  },
+}));
+
+// ----------------------------------------------------------------------
+
+export default function HomeHeroKorale() {
+  return (
+    <HeroRoot>
+      <CoralBackdrop src="/assets/korale/hero-coral-pattern.svg" alt="Korale coral texture" />
+      <CoralAccent src="/assets/korale/hero-coral-reef.svg" alt="Korale coral reef" />
+
+      <Container component={MotionContainer} maxWidth="lg" sx={{ position: 'relative', zIndex: 1 }}>
+        <Stack spacing={6} maxWidth={720}>
+          <m.div variants={varFade().inUp}>
+            <Typography variant="overline" sx={{ color: 'common.white', letterSpacing: 2 }}>
+              Workforce Leasing, Reimagined
+            </Typography>
+          </m.div>
+
+          <m.div variants={varFade().inUp}>
+            <Typography variant="h2" sx={{ fontSize: { xs: 40, md: 64 }, fontWeight: 800, lineHeight: 1.1 }}>
+              Shape resilient teams with Korale&apos;s people-first consultancy.
+            </Typography>
+          </m.div>
+
+          <m.div variants={varFade().inUp}>
+            <Typography sx={{ color: alpha('#FFFFFF', 0.88), fontSize: { xs: 18, md: 20 } }}>
+              We connect the right specialists to the right challenges, blending leasing flexibility with
+              leadership coaching so your delivery squads stay adaptive, inclusive, and future-ready.
+            </Typography>
+          </m.div>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+            <m.div variants={varFade().inUp}>
+              <Button size="large" color="secondary" variant="contained">
+                Build my Korale team
+              </Button>
+            </m.div>
+
+            <m.div variants={varFade().inUp}>
+              <Button size="large" color="inherit" variant="outlined" sx={{ borderColor: alpha('#FFFFFF', 0.48) }}>
+                Discover our playbooks
+              </Button>
+            </m.div>
+          </Stack>
+        </Stack>
+      </Container>
+    </HeroRoot>
+  );
+}

--- a/src/sections/home/home-services.tsx
+++ b/src/sections/home/home-services.tsx
@@ -3,7 +3,7 @@ import Chip from '@mui/material/Chip';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Container from '@mui/material/Container';
-import Grid from '@mui/material/Unstable_Grid2';
+import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { alpha, styled } from '@mui/material/styles';
 
@@ -59,7 +59,7 @@ export default function HomeServices() {
 
         <Grid container spacing={4} sx={{ mt: { xs: 6, md: 8 } }}>
           {capabilities.map((capability) => (
-            <Grid key={capability.title} xs={12} md={4}>
+            <Grid key={capability.title} size={{ xs: 12, md: 4 }}>
               <CapabilityCard>
                 <Stack spacing={3}>
                   <Box>

--- a/src/sections/home/home-services.tsx
+++ b/src/sections/home/home-services.tsx
@@ -1,0 +1,85 @@
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Container from '@mui/material/Container';
+import Grid from '@mui/material/Unstable_Grid2';
+import Typography from '@mui/material/Typography';
+import { alpha, styled } from '@mui/material/styles';
+
+// ----------------------------------------------------------------------
+
+const CapabilityCard = styled(Paper)(({ theme }) => ({
+  height: '100%',
+  padding: theme.spacing(4),
+  borderRadius: theme.spacing(3),
+  backgroundColor: alpha(theme.palette.background.default, theme.palette.mode === 'light' ? 0.75 : 0.5),
+  border: `1px solid ${alpha(theme.palette.primary.main, 0.16)}`,
+  boxShadow: `0 30px 60px ${alpha(theme.palette.grey[900], theme.palette.mode === 'light' ? 0.12 : 0.4)}`,
+  backdropFilter: 'blur(12px)',
+}));
+
+const capabilities = [
+  {
+    title: 'Korale Mapping',
+    description:
+      'Align your roadmap to the human skills it needs. We analyse delivery rituals, velocity, and culture to build dynamic leasing plans.',
+    highlights: ['Capability audit', 'Squad design', 'Leadership pairing'],
+  },
+  {
+    title: 'Adaptive Staffing Pods',
+    description:
+      'Flexible, coral-like structures of specialists that scale with tides of demand. Always guided by our Korale talent partners.',
+    highlights: ['On-demand specialists', 'Product & data leads', 'Progress rituals'],
+  },
+  {
+    title: 'Enablement & Coaching',
+    description:
+      'We coach embedded leads and sponsors to keep energy high and psychological safety thriving across leased teams.',
+    highlights: ['Executive labs', 'Squad retrospectives', 'DEI storytelling'],
+  },
+];
+
+// ----------------------------------------------------------------------
+
+export default function HomeServices() {
+  return (
+    <Box component="section" sx={{ py: { xs: 12, md: 16 } }}>
+      <Container maxWidth="lg">
+        <Stack spacing={3} sx={{ textAlign: { xs: 'left', md: 'center' }, maxWidth: 720, mx: { md: 'auto' } }}>
+          <Typography variant="overline" color="primary">Korale capabilities</Typography>
+          <Typography variant="h3" sx={{ fontWeight: 800 }}>
+            Coral-inspired operating models for modern teams.
+          </Typography>
+          <Typography sx={{ color: 'text.secondary', fontSize: { xs: 18, md: 20 } }}>
+            Our consultants blend leasing agility with embedded leadership support so your squads can absorb
+            change and still deliver with heart.
+          </Typography>
+        </Stack>
+
+        <Grid container spacing={4} sx={{ mt: { xs: 6, md: 8 } }}>
+          {capabilities.map((capability) => (
+            <Grid key={capability.title} xs={12} md={4}>
+              <CapabilityCard>
+                <Stack spacing={3}>
+                  <Box>
+                    <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                      {capability.title}
+                    </Typography>
+                    <Typography sx={{ color: 'text.secondary', mt: 1 }}>{capability.description}</Typography>
+                  </Box>
+
+                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                    {capability.highlights.map((highlight) => (
+                      <Chip key={highlight} label={highlight} color="primary" variant="soft" />
+                    ))}
+                  </Stack>
+                </Stack>
+              </CapabilityCard>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </Box>
+  );
+}

--- a/src/sections/home/home-testimonials.tsx
+++ b/src/sections/home/home-testimonials.tsx
@@ -1,0 +1,85 @@
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Avatar from '@mui/material/Avatar';
+import Rating from '@mui/material/Rating';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import { alpha, styled } from '@mui/material/styles';
+
+// ----------------------------------------------------------------------
+
+const TestimonialCard = styled(Paper)(({ theme }) => ({
+  height: '100%',
+  padding: theme.spacing(4),
+  borderRadius: theme.spacing(3),
+  background: alpha(theme.palette.common.white, theme.palette.mode === 'light' ? 0.75 : 0.1),
+  border: `1px solid ${alpha(theme.palette.primary.light, 0.3)}`,
+  boxShadow: `0 25px 50px ${alpha(theme.palette.grey[900], theme.palette.mode === 'light' ? 0.15 : 0.5)}`,
+  backdropFilter: 'blur(14px)',
+}));
+
+const testimonials = [
+  {
+    name: 'Carina West',
+    role: 'Head of Digital, Seastar Bank',
+    quote:
+      'Korale delivered a blended team that felt like our own people within days. Their rituals and coaching kept everyone energised through regulatory sprints.',
+  },
+  {
+    name: 'Josef Adeyemi',
+    role: 'VP Product, NorthCurrent Energy',
+    quote:
+      'The Korale pod understood our culture quickly and lifted our data practice. We finally have a leasing model that scales responsibly.',
+  },
+  {
+    name: 'Linh Tran',
+    role: 'CX Director, Lotus Mobility',
+    quote:
+      'Storytelling strategists from Korale reframed our onboarding journey and empowered our internal squad to keep iterating with empathy.',
+  },
+];
+
+// ----------------------------------------------------------------------
+
+export default function HomeTestimonials() {
+  return (
+    <Box component="section" sx={{ py: { xs: 12, md: 16 } }}>
+      <Container maxWidth="lg">
+        <Stack spacing={3} sx={{ textAlign: 'center', maxWidth: 720, mx: 'auto' }}>
+          <Typography variant="overline" color="primary">
+            Voices from the reef
+          </Typography>
+          <Typography variant="h3" sx={{ fontWeight: 800 }}>
+            Leaders choose Korale for sustained momentum.
+          </Typography>
+        </Stack>
+
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} sx={{ mt: { xs: 6, md: 8 } }}>
+          {testimonials.map((testimonial) => (
+            <TestimonialCard key={testimonial.name}>
+              <Stack spacing={3}>
+                <Rating value={5} readOnly sx={{ color: 'secondary.main' }} />
+                <Typography sx={{ fontSize: { xs: 18, md: 20 }, color: 'text.primary' }}>
+                  “{testimonial.quote}”
+                </Typography>
+
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <Avatar sx={{ bgcolor: 'secondary.main' }}>{testimonial.name.charAt(0)}</Avatar>
+                  <Box>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                      {testimonial.name}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                      {testimonial.role}
+                    </Typography>
+                  </Box>
+                </Stack>
+              </Stack>
+            </TestimonialCard>
+          ))}
+        </Stack>
+      </Container>
+    </Box>
+  );
+}

--- a/src/sections/home/view/home-view.tsx
+++ b/src/sections/home/view/home-view.tsx
@@ -1,46 +1,14 @@
 import { useScroll } from 'framer-motion';
 
 import Box from '@mui/material/Box';
-import { styled } from '@mui/material/styles';
 
 import ScrollProgress from 'src/components/scroll-progress';
 
-import HomeHero from '../home-hero';
-import HomeMinimal from '../home-minimal';
-import HomePricing from '../home-pricing';
-import HomeDarkMode from '../home-dark-mode';
-import HomeLookingFor from '../home-looking-for';
-import HomeForDesigner from '../home-for-designer';
-import HomeColorPresets from '../home-color-presets';
-import HomeAdvertisement from '../home-advertisement';
-import HomeCleanInterfaces from '../home-clean-interfaces';
-import HomeHugePackElements from '../home-hugepack-elements';
-
-// ----------------------------------------------------------------------
-
-type StyledPolygonProps = {
-  anchor?: 'top' | 'bottom';
-};
-
-const StyledPolygon = styled('div')<StyledPolygonProps>(({ anchor = 'top', theme }) => ({
-  left: 0,
-  zIndex: 9,
-  height: 80,
-  width: '100%',
-  position: 'absolute',
-  clipPath: 'polygon(0% 0%, 100% 100%, 0% 100%)',
-  backgroundColor: theme.palette.background.default,
-  display: 'block',
-  lineHeight: 0,
-  ...(anchor === 'top' && {
-    top: -1,
-    transform: 'scale(-1, -1)',
-  }),
-  ...(anchor === 'bottom' && {
-    bottom: -1,
-    backgroundColor: theme.palette.grey[900],
-  }),
-}));
+import HomeServices from '../home-services';
+import HomeHeroKorale from '../home-hero-korale';
+import HomeContactCta from '../home-contact-cta';
+import HomeTestimonials from '../home-testimonials';
+import HomeClientHighlights from '../home-client-highlights';
 
 // ----------------------------------------------------------------------
 
@@ -51,36 +19,13 @@ export default function HomeView() {
     <>
       <ScrollProgress scrollYProgress={scrollYProgress} />
 
-      <HomeHero />
+      <HomeHeroKorale />
 
-      <Box
-        sx={{
-          overflow: 'hidden',
-          position: 'relative',
-          bgcolor: 'background.default',
-        }}
-      >
-        <HomeMinimal />
-
-        <HomeHugePackElements />
-
-        <Box sx={{ position: 'relative' }}>
-          <StyledPolygon />
-          <HomeForDesigner />
-          <StyledPolygon anchor="bottom" />
-        </Box>
-
-        <HomeDarkMode />
-
-        <HomeColorPresets />
-
-        <HomeCleanInterfaces />
-
-        <HomePricing />
-
-        <HomeLookingFor />
-
-        <HomeAdvertisement />
+      <Box component="div" sx={{ bgcolor: 'background.default' }}>
+        <HomeServices />
+        <HomeClientHighlights />
+        <HomeTestimonials />
+        <HomeContactCta />
       </Box>
     </>
   );


### PR DESCRIPTION
## Summary
- add Korale-focused home hero, services, client highlights, testimonials, and contact sections with people-leasing storytelling
- refresh the home view to use the new Korale sequence and simplify the layout flow
- add coral-inspired background illustrations for the updated hero experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ea0aebf260832289c6f682af6eca9f